### PR TITLE
Fix for IE9

### DIFF
--- a/visibly.js
+++ b/visibly.js
@@ -106,8 +106,8 @@
             try { /*if no native page visibility support found..*/
                 if (!(this.isSupported())) {
                     if (this.q.addEventListener) { /*for browsers without focusin/out support eg. firefox, opera use focus/blur*/
-                        window.addEventListener(this.m[0], this._visible, 1);
-                        window.addEventListener(this.m[1], this._hidden, 1);
+                        window.addEventListener(this.m[0], this._visible, false);
+                        window.addEventListener(this.m[1], this._hidden, false);
                     } else { /*IE <10s most reliable focus events are onfocusin/onfocusout*/
                         if (this.q.attachEvent) {
                             this.q.attachEvent('onfocusin', this._visible);


### PR DESCRIPTION
We had an issue where the events are triggered multiple times on IE9, and they are also triggered when navigating within the page using hash url's. The issue is clearly visible in this video:

https://youtu.be/u_G1HX5s20o

However, I don't know if this will break functionality for any other browser.
